### PR TITLE
Add commands to generate initial .go.yaml and to "freeze" the current versions of dependencies

### DIFF
--- a/common/dep.go
+++ b/common/dep.go
@@ -8,14 +8,14 @@ type Dependency struct {
 	// Path is the path the dependency should be installed to. This should
 	// correspond to whatever the dependency expects to be imported as. For
 	// example: "code.google.com/p/protobuf". Default: Value of Location field
-	Path string `yaml:"path"`
+	Path string `yaml:"path,omitempty"`
 
 	// Type is what kind of project the dependency should be fetched as.
 	// Available options are: goget, git, hg. Default: goget.
-	Type string `yaml:"type"`
+	Type string `yaml:"type,omitempty"`
 
 	// Reference is only valueable for version-control Types (e.g. git). It can
 	// be any valid reference in that version control system (branch name, tag,
 	// commit hash). Default depends on the Type, git is "master", hg is "tip".
-	Reference string `yaml:"ref"`
+	Reference string `yaml:"ref,omitempty"`
 }

--- a/env/deps/git.go
+++ b/env/deps/git.go
@@ -49,3 +49,27 @@ func Git(depdir string, dep *Dependency) error {
 	return err
 
 }
+
+func GitInfo(path string) (string, string, error) {
+	origcwd, err := os.Getwd()
+	if err != nil {
+		return "", "", err
+	}
+
+	err = os.Chdir(path)
+	if err != nil {
+		return "", "", err
+	}
+	defer os.Chdir(origcwd)
+
+	ref, err := exec.TrimmedCmd("git", "rev-parse", "--verify", "HEAD")
+	if err != nil {
+		return "", "", err
+	}
+	url, err := exec.TrimmedCmd("git", "config", "--get", "remote.origin.url")
+	if err != nil {
+		return "", "", err
+	}
+
+	return url, ref, nil
+}

--- a/env/deps/hg.go
+++ b/env/deps/hg.go
@@ -43,3 +43,26 @@ func Hg(depdir string, dep *Dependency) error {
 	return err
 
 }
+
+func HgInfo(path string) (string, string, error) {
+	origcwd, err := os.Getwd()
+	if err != nil {
+		return "", "", err
+	}
+
+	err = os.Chdir(path)
+	if err != nil {
+		return "", "", err
+	}
+	defer os.Chdir(origcwd)
+
+	ref, err := exec.TrimmedCmd("hg", "parent", "--template", "{node}")
+	if err != nil {
+		return "", "", err
+	}
+	url, err := exec.TrimmedCmd("hg", "paths", "default")
+	if err != nil {
+		return "", "", err
+	}
+	return url, ref, nil
+}

--- a/env/imports.go
+++ b/env/imports.go
@@ -1,0 +1,133 @@
+package env
+
+import (
+	"fmt"
+	. "github.com/mediocregopher/goat/common"
+	"github.com/mediocregopher/goat/env/deps"
+	"go/build"
+	"os"
+	"path"
+	"sort"
+	"strings"
+)
+
+var srcDirs []string
+
+func getImports(path string) ([]string, error) {
+	imports, err := getImportsMap(path)
+	if err != nil {
+		return nil, err
+	}
+	packages := make([]string, 0, len(imports))
+	for k, _ := range imports {
+		packages = append(packages, k)
+	}
+	sort.Strings(packages)
+	return packages, nil
+}
+
+func getImportsMap(path string) (map[string]Dependency, error) {
+	pkg, err := build.ImportDir(path, 0)
+	if err != nil {
+		return nil, err
+	}
+	imports := make(map[string]Dependency)
+	walkImports(path, imports, pkg)
+	return imports, nil
+}
+
+func walkImports(basePath string, imports map[string]Dependency, pkg *build.Package) {
+	for _, importPath := range pkg.Imports {
+		subPkg, err := tryImport(importPath)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+		// Skip stdlib packages and sub-packages
+		if subPkg.SrcRoot == srcDirs[0] {
+			continue
+		}
+
+		// Leave sub-packages out of the dependency list, but maybe still scan their deps
+		if !strings.HasPrefix(subPkg.Dir, basePath) {
+			imports[importPath] = Dependency{Location: importPath}
+		}
+		// Don't recurse into packages which have their own .go.yaml file
+		if IsProjRoot(subPkg.Dir) {
+			fmt.Printf("Not scanning %s since it has its own .go.yaml\n", subPkg.ImportPath)
+			continue
+		}
+		walkImports(basePath, imports, subPkg)
+	}
+}
+
+func tryImport(path string) (*build.Package, error) {
+	for _, srcDir := range srcDirs {
+		pkg, err := build.Import(path, srcDir, 0)
+		if err == nil {
+			return pkg, nil
+		}
+	}
+	return nil, fmt.Errorf("Couldn't find %s in any of %v", path, srcDirs)
+}
+
+func init() {
+	srcDirs = build.Default.SrcDirs()
+}
+
+func FreezeImport(path string) (RepoType, string, string, error) {
+	pkg, err := tryImport(path)
+	if err != nil {
+		return NoRepo, "", "", err
+	}
+	repoDir, repoType := repoRoot(pkg)
+
+	var url, ref string
+	switch repoType {
+	case NoRepo:
+		return NoRepo, "", "", fmt.Errorf("No repo found for %s", pkg.ImportPath)
+	case Git:
+		url, ref, err = deps.GitInfo(repoDir)
+	case Hg:
+		url, ref, err = deps.HgInfo(repoDir)
+	}
+	if err != nil {
+		return NoRepo, "", "", err
+	}
+
+	return repoType, url, ref, nil
+}
+
+type RepoType int
+
+const (
+	NoRepo RepoType = iota
+	Git
+	Hg
+)
+
+func (rt RepoType) String() string {
+	switch rt {
+	case NoRepo:
+		return ""
+	case Git:
+		return "git"
+	case Hg:
+		return "hg"
+	default:
+		return ""
+	}
+}
+
+func repoRoot(pkg *build.Package) (string, RepoType) {
+	for p := pkg.ImportPath; p != "."; p = path.Dir(p) {
+		dir := path.Join(pkg.SrcRoot, p)
+		if _, err := os.Stat(path.Join(dir, ".git")); !os.IsNotExist(err) {
+			return dir, Git
+		}
+		if _, err := os.Stat(path.Join(dir, ".hg")); !os.IsNotExist(err) {
+			return dir, Hg
+		}
+	}
+	return "", NoRepo
+}

--- a/goat.go
+++ b/goat.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"github.com/mediocregopher/goat/env"
 	"github.com/mediocregopher/goat/exec"
@@ -29,6 +30,13 @@ The commands are:
     deps    Read the .go.yaml file for this project and set up dependencies in
             the dependencies folder specified (default ".deps"). Recursively
             download dependencies wherever a .go.yaml file is encountered
+
+    freeze  Scan through the list of dependencies in .go.yaml and update their
+            references to the current ones installed.
+
+    gen     Generate an initial .go.yaml file for this project based on imports
+            done in this package and any imported packages (except for 
+            sub-packages which also have .go.yaml files).
 
     ghelp   Show this dialog
 
@@ -68,6 +76,52 @@ func main() {
 	}
 
 	switch args[0] {
+	case "gen":
+		var err error
+		genFlags := flag.NewFlagSet("goat gen", flag.ExitOnError)
+		forceUpdate := genFlags.Bool("update", false, "Update an existing .go.yaml file")
+		freeze := genFlags.Bool("freeze", false, "Lock in the current git or hg revision of dependencies")
+		genFlags.Parse(args[1:])
+		if genv != nil {
+			if !*forceUpdate {
+				fatal(errors.New(".go.yaml file already exists, use -update to force update"))
+			}
+			err = genv.UpdateDependencies()
+		} else {
+			pwd, err := os.Getwd()
+			if err != nil {
+				fatal(err)
+			}
+			genv, err = env.GenGoatEnv(pwd)
+		}
+		if err != nil {
+			fatal(err)
+		}
+		if *freeze {
+			err = genv.FreezeDependencies()
+			if err != nil {
+				fatal(err)
+			}
+		}
+		err = genv.WriteConf()
+		if err != nil {
+			fatal(err)
+		}
+		fmt.Println(".go.yaml has been generated. Add a proper path setting if you haven't already")
+	case "freeze":
+		if genv != nil {
+			err := genv.FreezeDependencies()
+			if err != nil {
+				fatal(err)
+			}
+		} else {
+			fatal(errors.New(".go.yaml file not found on current path"))
+		}
+		err = genv.WriteConf()
+		if err != nil {
+			fatal(err)
+		}
+		fmt.Println(".go.yaml has been updated")
 	case "deps":
 		if genv != nil {
 			err := genv.FetchDependencies(genv.AbsDepDir())

--- a/goat.go
+++ b/goat.go
@@ -93,6 +93,10 @@ func main() {
 				fatal(err)
 			}
 			genv, err = env.GenGoatEnv(pwd)
+			if err != nil {
+				fatal(err)
+			}
+			err = genv.PrependToGoPath()
 		}
 		if err != nil {
 			fatal(err)


### PR DESCRIPTION
These changes make it easier for folks to start using goat and to update dependencies without having to hand-edit their .go.yaml file.
