### PR TITLE
Move to gopkg.in for YAML

### DIFF
--- a/.go.yaml
+++ b/.go.yaml
@@ -1,4 +1,4 @@
 ---
 path: github.com/mediocregopher/goat
 deps:
-  - loc: launchpad.net/goyaml
+  - loc: gopkg.in/yaml.v1

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ bin:
 	mkdir bin
 
 deps: $(GOATLOOPBACK)
-	$(GOPATH) go get launchpad.net/goyaml
+	$(GOPATH) go get gopkg.in/yaml.v1
 
 $(GOATLOOPBACK):
 	mkdir -p $(GOATLOOPBACK)/..

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Change .go.yaml to read:
 ---
 path: github.com/user/newproject
 deps:
-    - loc: launchpad.net/goyaml # the same path you would use for go get
+    - loc: gopkg.in/yaml.v1 # the same path you would use for go get
 ```
 
 **Adding a dependency with a specific version:**
@@ -58,7 +58,7 @@ Change .go.yaml to read:
 ---
 path: github.com/user/newproject
 deps:
-    - loc: launchpad.net/goyaml # the same path you would use for go get
+    - loc: gopkg.in/yaml.v1 # the same path you would use for go get
 
     - loc: https://github.com/mediocregopher/flagconfig.git
       type: git

--- a/env/env.go
+++ b/env/env.go
@@ -3,7 +3,7 @@ package env
 import (
 	. "github.com/mediocregopher/goat/common"
 	"io/ioutil"
-	"launchpad.net/goyaml"
+	"gopkg.in/yaml.v1"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -15,7 +15,7 @@ var PROJFILE = ".go.yaml"
 // structure
 func unmarshal(genvraw []byte) (*GoatEnv, error) {
 	genv := GoatEnv{}
-	if err := goyaml.Unmarshal(genvraw, &genv); err != nil {
+	if err := yaml.Unmarshal(genvraw, &genv); err != nil {
 		return nil, err
 	}
 	return &genv, nil


### PR DESCRIPTION
The launchpad repository for YAML is deprecated and has moved to GitHub (go-yaml/yaml). The maintainer, @niemeyer, is also the maintainer of gopkg.in and recommends that you use it for the YAML package.

Another advantage, albeit mostly theoretical: if there were ever a v2 of the YAML package, gopkg.in lets you use `go get github.com/mediocregopher/goat` without risking breakage.

The APIs are the same for these packages, so there's no real code changes.
